### PR TITLE
Remove dep on unnecessary data block

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,0 @@
-data "azurerm_resource_group" "base" {
-  name = var.resource_group_name
-}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,12 +17,13 @@ resource "azurerm_resource_group" "test_group" {
 }
 
 module "terraform-azurerm-event-hub" {
-  source              = "../../"
-  resource_group_name = azurerm_resource_group.test_group.name
-  prefix              = [local.unique_name_stub]
-  suffix              = [local.unique_name_stub]
-  sku                 = "Basic"
-  capacity            = "2"
+  source                  = "../../"
+  resource_group_name     = azurerm_resource_group.test_group.name
+  resource_group_location = azurerm_resource_group.test_group.location
+  prefix                  = [local.unique_name_stub]
+  suffix                  = [local.unique_name_stub]
+  sku                     = "Basic"
+  capacity                = "2"
   event_hubs = {
     "eh-test" = {
       name              = "${module.naming.eventhub.slug}-${local.unique_name_stub}"

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_resource_group" "test_group" {
 }
 
 module "terraform-azurerm-event-hub" {
-  source              = "../../"
-  resource_group_name = azurerm_resource_group.test_group.name
+  source                  = "../../"
+  resource_group_name     = azurerm_resource_group.test_group.name
+  resource_group_location = azurerm_resource_group.test_group.location
 }

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_eventhub_namespace" "namespace" {
 
 resource "azurerm_eventhub" "eventhubs" {
   for_each            = local.event_hub_to_auth_rule_mapping
-  resource_group_name = var.resource_group_location
+  resource_group_name = var.resource_group_name
   name                = each.value.event_hub_name
   namespace_name      = azurerm_eventhub_namespace.namespace.name
   partition_count     = each.value.event_hub_partition_count
@@ -48,7 +48,7 @@ resource "azurerm_eventhub" "eventhubs" {
 
 resource "azurerm_eventhub_authorization_rule" "authorisation_rule" {
   for_each            = local.event_hub_to_auth_rule_mapping
-  resource_group_name = var.resource_group_location
+  resource_group_name = var.resource_group_name
   name                = each.value.authorisation_rule_name
   namespace_name      = azurerm_eventhub_namespace.namespace.name
   eventhub_name       = each.value.event_hub_name

--- a/main.tf
+++ b/main.tf
@@ -31,15 +31,15 @@ locals {
 
 resource "azurerm_eventhub_namespace" "namespace" {
   name                = module.naming.eventhub_namespace.name_unique
-  resource_group_name = data.azurerm_resource_group.base.name
-  location            = data.azurerm_resource_group.base.location
+  resource_group_name = var.resource_group_name
+  location            = var.resource_group_location
   sku                 = var.sku
   capacity            = var.capacity
 }
 
 resource "azurerm_eventhub" "eventhubs" {
   for_each            = local.event_hub_to_auth_rule_mapping
-  resource_group_name = data.azurerm_resource_group.base.name
+  resource_group_name = var.resource_group_location
   name                = each.value.event_hub_name
   namespace_name      = azurerm_eventhub_namespace.namespace.name
   partition_count     = each.value.event_hub_partition_count
@@ -48,7 +48,7 @@ resource "azurerm_eventhub" "eventhubs" {
 
 resource "azurerm_eventhub_authorization_rule" "authorisation_rule" {
   for_each            = local.event_hub_to_auth_rule_mapping
-  resource_group_name = data.azurerm_resource_group.base.name
+  resource_group_name = var.resource_group_location
   name                = each.value.authorisation_rule_name
   namespace_name      = azurerm_eventhub_namespace.namespace.name
   eventhub_name       = each.value.event_hub_name

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,12 @@
 #Required variables
 variable "resource_group_name" {
   type        = string
-  description = "The Resource Group in which to put the Storage Accounts."
+  description = "The Resource Group name in which to put the Storage Accounts."
+}
+
+variable "resource_group_location" {
+  type        = string
+  description = "The Resource Group location in which to put the Storage Accounts."
 }
 
 #Optional variables


### PR DESCRIPTION
Relying on data block to fetch rg.location causes issues when adding this module to existing deployments when the calling module is also newly creating the RG. The plan will fail on refresh. Since data is only being used a convenience to fetch the rg location I've added it to the variables. Examples updated to reflect.